### PR TITLE
Update DataCounter.js

### DIFF
--- a/src/DataCounter/widget/DataCounter.js
+++ b/src/DataCounter/widget/DataCounter.js
@@ -108,8 +108,10 @@ define([
        		mx.data.get({ 
  			    xpath: "//"+this.RetrieveObject+this.Constraint,
  			    count: true,
-                callback: dojoLang.hitch(this,function(ObjectList) {
-                    dojoHtml.set(this.CountResult,ObjectList.length.toString());
+                callback: dojoLang.hitch(this, function(ObjectList) {
+                    if (this.CountResult != null) {
+                        dojoHtml.set(this.CountResult,ObjectList.length.toString());
+                    }
     			})
             });
        	}


### PR DESCRIPTION
Update: Fix for Mendix 8.x fixed error: Cannot use 'in' operator to search for 'innerHTML' in null TypeError: Cannot use 'in' operator to search for 'innerHTML' in null